### PR TITLE
Install gtk3 version of keybinder

### DIFF
--- a/ansible/tasks/freebsd/builder-package-install.yml
+++ b/ansible/tasks/freebsd/builder-package-install.yml
@@ -36,6 +36,7 @@
                 - clutter
                 - libXmu
                 - keybinder
+                - keybinder-gtk3
                 - vte3
                 - vala
                 - gstreamer1-plugins-core

--- a/ansible/tasks/openbsd/builder-package-install.yml
+++ b/ansible/tasks/openbsd/builder-package-install.yml
@@ -148,6 +148,11 @@
             name: keybinder
             state: latest
 
+        - name: Install keybinder3 package
+          package:
+            name: keybinder3
+            state: latest
+
         - name: Install vte3 package
           package:
             name: vte3


### PR DESCRIPTION
This should fix the xfce4-volumed-pulse compilation on openbsd, freebsd and dragonflybsd