### PR TITLE
Various improvements

### DIFF
--- a/ansible/jenkins-jobs/job-template.yml
+++ b/ansible/jenkins-jobs/job-template.yml
@@ -16,7 +16,7 @@
           url: '{url}'
           branches:
               - origin/master
-          wipe-workspace: false
+          wipe-workspace: true
           skip-tag: true
           per-build-tag: false
           git-config-name: "Xfce Buildbot"
@@ -27,9 +27,11 @@
           PKG_CONFIG_PATH=/usr/local/lib/pkgconfig:/usr/local/libdata/pkgconfig:/usr/lib/pkgconfig
           LD_LIBRARY_PATH=/usr/local/lib:/usr/lib
           PATH=/usr/gnu/bin/:/usr/local/sbin:/usr/local/bin:/usr/bin:/usr/sbin:/sbin:/usr/gnu/bin:/bin:/usr/X11R6/bin
+          LDFLAGS="-L/usr/lib -L/usr/local/lib"
           export PATH
           export PKG_CONFIG_PATH
           export LD_LIBRARY_PATH
+          export LDFLAGS
           unamestr=`uname`
           if [[ $unamestr == OpenBSD ]]; then
             AUTOMAKE_VERSION=1.15
@@ -37,7 +39,6 @@
             export AUTOMAKE_VERSION
             export AUTOCONF_VERSION
             export CC=clang
-            option="--disable-introspection"
           fi
           if [[ -f autogen.sh ]]; then
             echo -e "\e[31m running: ./autogen.sh \e[0m"

--- a/ansible/jenkins-jobs/multijobs.yml
+++ b/ansible/jenkins-jobs/multijobs.yml
@@ -8,8 +8,6 @@
     name: Xfce-Core
     project-type: multijob
     concurrent: true
-    triggers:
-        - timed: "@daily"
     builders:
         - multijob:
             name: xfce4-dev-tools

--- a/ansible/jenkins-playbook.yml
+++ b/ansible/jenkins-playbook.yml
@@ -25,7 +25,7 @@
           - openjdk-8-jdk
     - role: geerlingguy.jenkins
 
-  tasks:
+  post_tasks:
     - name: install packages needed by the jenkins master
       include: tasks/jenkins/jenkins-master-package-install.yml
 

--- a/ansible/tasks/ubuntu/builder-package-install.yml
+++ b/ansible/tasks/ubuntu/builder-package-install.yml
@@ -41,7 +41,7 @@
                 - gobject-introspection
                 - libgtk-3-0
                 - libgtk-3-dev
-                - openjdk-8-jdk
+                - default-jre
                 - libdbus-glib-1-dev
                 - libupower-glib-dev
                 - libwnck-3-dev

--- a/ansible/vars/common_vars.yml
+++ b/ansible/vars/common_vars.yml
@@ -16,7 +16,7 @@ jenkins_package_state: latest
 jenkins_admin_username: 'admin'
 jenkins_admin_password: 'admin'
 
-swarm_client_version: 3.14
+swarm_client_version: 3.17
 
 openbsd_java_version: 1.8.0
 


### PR DESCRIPTION
- Bump swarm client version
- Clean workspace between every builds
- Add correct LDFLAGS for OpenBSD
- Remove daily build trigger (run it on demand)
- Use default-jre package for new ubuntu versions
- Use post_tasks in playbook to force jenkins installation before other
tasks